### PR TITLE
Return overridden field format for groupby fields.

### DIFF
--- a/model_report/report.py
+++ b/model_report/report.py
@@ -178,6 +178,11 @@ class ReportAdmin(object):
                     value = getattr(obj, 'get_%s_display' % field)()
         except:
             pass
+
+        if field in self.override_field_formats:
+            value = ReportValue(value)
+            value.format = self.override_field_formats[field]
+
         return value
 
     def get_value_text(self, value, index, model_field):


### PR DESCRIPTION
Override the field format for the title of a group in the report table, just as the field would appear elsewhere in the table.
