### PR TITLE
str objects must be treated the same as unicode in this case

### DIFF
--- a/model_report/report.py
+++ b/model_report/report.py
@@ -473,7 +473,7 @@ class ReportAdmin(object):
                                     row_index += 1
                                 elif row.is_caption:
                                     for index, x in enumerate(row):
-                                        if not isinstance(x, unicode):
+                                        if not isinstance(x, (unicode, str)):
                                             sheet1.write(row_index, index, x.text(), stylebold)
                                         else:
                                             sheet1.write(row_index, index, x, stylebold)


### PR DESCRIPTION
I was getting the following error while exporting results when the data was grouped by a field.  

Location: model_report/report.py in get_render_context, line 477
Exception Value: 'str' object has no attribute 'text'

So I changed the code to treat str objects in the same way as unicode in this section of the code.
