### PR TITLE
fixing the package bugs. 

### DIFF
--- a/model_report/report.py
+++ b/model_report/report.py
@@ -559,7 +559,8 @@ class ReportAdmin(object):
 
         if isinstance(context_or_response, HttpResponse):
             return context_or_response
-        return render_to_response('model_report/report.html', context_or_response, context_instance=RequestContext(request))
+        template_name = self.template_name or 'model_report/report.html'
+        return render_to_response(template_name, context_or_response, context_instance=RequestContext(request))
 
     def has_report_totals(self):
         return not (not self.report_totals)

--- a/model_report/templates/model_report/report.html
+++ b/model_report/templates/model_report/report.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "admin/base.html" %}
 {% load i18n %}
 
 {% block title %}{% trans "Report" %}: {{ report.get_title }}{% endblock %}

--- a/model_report/templates/model_report/report_list.html
+++ b/model_report/templates/model_report/report_list.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "admin/base.html" %}
 {% load i18n %}
 
 {% block title %}{% trans "Report list" %}{% endblock %}


### PR DESCRIPTION
-there is no such template base.html in the model-report package and it is giving error. it should inherit from the admin/base.html
-  utilizing the model-report custom template if given by user, which was not utilized before.
