### PR TITLE
docs: Fix simple typo, variuos -> various

### DIFF
--- a/example/test_project/static/model_report/js/highcharts/js/highcharts.src.js
+++ b/example/test_project/static/model_report/js/highcharts/js/highcharts.src.js
@@ -433,7 +433,7 @@ function getPosition(el) {
 }
 
 /**
- * Helper class that contains variuos counters that are local to the chart.
+ * Helper class that contains various counters that are local to the chart.
  */
 function ChartCounters() {
 	this.color = 0;

--- a/model_report/static/model_report/js/highcharts/js/highcharts.src.js
+++ b/model_report/static/model_report/js/highcharts/js/highcharts.src.js
@@ -433,7 +433,7 @@ function getPosition(el) {
 }
 
 /**
- * Helper class that contains variuos counters that are local to the chart.
+ * Helper class that contains various counters that are local to the chart.
  */
 function ChartCounters() {
 	this.color = 0;


### PR DESCRIPTION
There is a small typo in example/test_project/static/model_report/js/highcharts/js/highcharts.src.js, model_report/static/model_report/js/highcharts/js/highcharts.src.js.

Should read `various` rather than `variuos`.

